### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,9 @@ For example;
  - `{owner}/{repo}@{ref}` - Public action in `github.com/{owner}/{repo}`
  - `{owner}/{repo}/{path}@{ref}` - Public action under `{path}` in
    `github.com/{owner}/{repo}`.
- - `./{path}` - Local action under local `{path}`, IE `./.github/actions/my-action`.
+ - `./{path}` - Local action under local `{path}`, IE `./.github/actions/{action-name}`.
 
 As it only makes sense to reference composite actions, the `docker://` form isn't supported.
-
-As you frequently want to include local actions, `actions-includes` extends the
-`{action-name}` syntax to also support;
-
- - `/{name}` - Local action under `./.github/actions/{name}`.
 
 This is how composite actions should have worked.
 


### PR DESCRIPTION
The README previously stated incorrectly that `/{action-name}` would be mapped to `./.github/actions/{action-name}`, when it is actually mapped to `./.github/includes/actions/{action-name}`.

Since `./github/includes/actions/...` seems to be used extensively in the actions-includes code, it seems best/easiest to update the README to remove this claim. Users can just use the normal filepath syntax: `./.github/actions/{action-name}`