### PR TITLE
Support reusable workflows

### DIFF
--- a/actions_includes/__init__.py
+++ b/actions_includes/__init__.py
@@ -530,7 +530,11 @@ def expand_step_run(current_filepath, v):
 
 
 def expand_job_steps(current_filepath, job_data):
-    assert 'steps' in job_data, pprint.pformat(job_data)
+    if 'steps' not in job_data:
+        # make sure this job is using reusable workflows,
+        # which don't have steps
+        assert 'uses' in job_data, pprint.pformat(job_data)
+        return job_data
 
     steps = list((current_filepath, s) for s in job_data['steps'])
 
@@ -963,7 +967,11 @@ def expand_workflow(current_workflow, to_path, insert_check_steps: bool):
     })
 
     for j in data['jobs'].values():
-        assert 'steps' in j, pprint.pformat(j)
+        if 'steps' not in j:
+            # make sure this job is using reusable workflows,
+            # which don't have steps
+            assert 'uses' in j, pprint.pformat(j)
+            continue
         steps = j['steps']
         assert isinstance(steps, list), pprint.pformat(j)
 


### PR DESCRIPTION
Reusable workflows are a new feature [1] that allow a workflow to be dispatched from another workflow.

Using reusable workflows involves creating a job with a `uses` key and no `steps` key [2].

This change allows these jobs to pass silently through actions-includes instead of causing a failure.

[1] https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/
[2] https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#calling-a-reusable-workflow