### PR TITLE
handle unary functions like toJSON, fromJSON

### DIFF
--- a/actions_includes/expressions.py
+++ b/actions_includes/expressions.py
@@ -158,6 +158,9 @@ def tokenizer(s):
     >>> p(tokenizer("inputs.use-me"))
     Lookup('inputs', 'use-me')
 
+    >>> p(tokenizer("fromJSON(env.test)"))
+    (<class 'exp.FromJSONF'>, Lookup('env', 'test'))
+
     >>> p(tokenizer("!startsWith(runner.os, 'Linux')"))
     (<class 'exp.NotF'>,
      (<class 'exp.StartsWithF'>, Lookup('runner', 'os'), 'Linux'))
@@ -239,6 +242,9 @@ def tokenizer(s):
                     #r = l(i[0], i[2])
                     #print('Eval: {}({}, {}) = {}'.format(l, i[0], i[2], r))
                     stack[-1][-1] = (l, i[0], i[2])
+                    continue
+                elif isinstance(l, type) and issubclass(l, UnaryFunction):
+                    stack[-1][-1] = (l, i)
                     continue
                 elif isinstance(l, type) and issubclass(l, VarArgsFunction):
                     o = [l]


### PR DESCRIPTION
We were having problems with workflows using `toJSON()` and `fromJSON()`:

Using the snippet from the [docs](https://docs.github.com/en/actions/learn-github-actions/expressions#example-returning-a-json-data-type), lightly modified: 
```
name: print
on: push
env:
  continue: true
  time: 3
jobs:
  job1:
    runs-on: ubuntu-latest
    steps:
      - continue-on-error: ${{ fromJSON(env.continue) }}
        timeout-minutes: ${{ fromJSON(env.time) }}
        run: echo "asdf"
```

When run through `actions_includes`, it generates the following error (truncated)

```
  File "<SNIP>/actions_includes/expressions.py", line 1301, in simplify
    o = tokens_eval(tokenizer(exp), context)
  File "<SNIP>/actions_includes/expressions.py", line 373, in tokens_eval
    assert not isinstance(t, list), t
AssertionError: [<class 'exp.FromJSONF'>, Lookup('env', 'continue')]
```

It _looks_ like maybe the `unaryFunction` case is missing from the tokenizer? It's certainly not returning what I'd expect. I took a quick stab at addressing that below, but I'm not sure it's the right fix.

It does work though! After this change, the tokenizer properly returns a tuple of the function and its arg.

I wasn't sure where to add tests - any suggestions?