### PR TITLE
fix: use GITHUB_TOKEN instead of GHA_CR_TOKEN for GHCR authentication

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -26,6 +26,10 @@ jobs:
     name: Push Docker image to GitHub Packages
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
     # Run a local registry
     services:
       registry:
@@ -51,8 +55,6 @@ jobs:
     - name: Push To
       id: push_to
       shell: python
-      env:
-        HAS_GHA_CR_TOKEN: ${{ secrets.GHA_CR_TOKEN != '' }}
       run: |
         import os
 
@@ -63,22 +65,25 @@ jobs:
 
         gh_repo = g('GITHUB_REPOSITORY')
         gh_event = g('GITHUB_EVENT_NAME')
-        has_cr_token = g('HAS_GHA_CR_TOKEN')
 
         i = []
 
         print("Adding local service.")
         i.append("localhost:5000/"+gh_repo)
 
-        if gh_event == 'push' and has_cr_token == 'true':
+        # Use GITHUB_TOKEN for authentication (always available)
+        if gh_event == 'push':
             print("Adding GitHub Container Repository (ghcr.io)")
             i.append("ghcr.io/{}/image".format(gh_repo))
         else:
-            print("Skipping GitHub Container Repository (ghcr.io)")
+            print("Skipping GitHub Container Repository (ghcr.io) for non-push events")
 
         l = ",".join(i)
         print("Final locations:", repr(l))
-        print("::set-output name=images::{}".format(l))
+
+        # Use environment file instead of deprecated set-output
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            f.write("images={}\n".format(l))
 
     - name: Docker meta
       id: docker_meta
@@ -97,11 +102,11 @@ jobs:
 
     - name: Login to GHCR
       if: ${{ contains(steps.push_to.outputs.images, 'ghcr.io') }}
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHA_CR_TOKEN }}
         registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
 #    - name: Login to local registry
 #      uses: docker/login-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ cython_debug/
 # Generated version file
 actions_includes/version.py
 docker/*.tar.gz
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary

- Replace custom `GHA_CR_TOKEN` PAT with built-in `GITHUB_TOKEN`
- Add `permissions` block with `packages: write`
- Simplify push logic (no need to check for token existence)
- Update `docker/login-action` from v1 to v3
- Fix deprecated `::set-output` command

## Background

The "Publish Docker image" workflow was failing on all `push` events because `GHA_CR_TOKEN` was invalid/expired. Pull requests succeeded only because they skip the ghcr.io push entirely.

See issue #52 for the full investigation.

## Changes

| Before | After |
|--------|-------|
| Custom PAT (`GHA_CR_TOKEN`) | Built-in `GITHUB_TOKEN` |
| Manual token management | Automatic rotation |
| Check if token exists | Always available |
| `::set-output` (deprecated) | `GITHUB_OUTPUT` env file |
| `docker/login-action@v1` | `docker/login-action@v3` |

## Test plan

- [ ] Verify PR checks pass (pull_request event - pushes to localhost only)
- [ ] After merge, verify push event successfully publishes to ghcr.io

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)